### PR TITLE
fix: Correct link to access app locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ git clone https://github.com/LionelMv/SI_Risk_Calculator.git
 ```
   python ./SI_RC/manage.py runserver
 ```
-The application should be available at http://localhost:8000/ through your browser
+The application should be available at http://localhost:8000/calculator through your browser
 
 ### How to use the app
 Check out this link: [About Page](https://www.iatlion.tech/calculator/about/)


### PR DESCRIPTION
Original link did not access app
Changed to http://localhost:8000/calculator