### PR TITLE
config: Hide secret information

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ Python3 and pip should be installed in your system.
 ```
 pip install -r ./SI_RC/requirements.txt
 ```
-  
+
+### Reaname ENVAMPLE
+Rename ```ENVSAMPLE``` file to ```.env```.
+**Note:** The ```.env``` file should only be used during development and not during production.
+
 ### Start up server
   
 ```

--- a/SI_RC/ENVSAMPLE
+++ b/SI_RC/ENVSAMPLE
@@ -1,0 +1,3 @@
+# Only used during development
+SECRET_KEY = 'django-insecure-a@@v#66z@21_$w&_0&nqz#o^)vsaycx*037%ze5wf4a5bie$im'
+DEBUG=True 

--- a/SI_RC/SI_RC/settings.py
+++ b/SI_RC/SI_RC/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
+from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,12 +21,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-a@@v#66z@21_$w&_0&nqz#o^)vsaycx*037%ze5wf4a5bie$im'
+SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = config('DEBUG', default=False, cast=bool)
 
-ALLOWED_HOSTS = ['si-risk-calculator.vercel.app',]
+ALLOWED_HOSTS = ['si-risk-calculator.vercel.app', '127.0.0.1']
 
 
 # Application definition

--- a/SI_RC/requirements.txt
+++ b/SI_RC/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.8.1
 Django==5.1.3
 djangorestframework==3.15.2
+python-decouple==3.8
 sqlparse==0.5.1
 whitenoise==6.8.2


### PR DESCRIPTION
- Hide the  SECRET_KEY variable.
- Config DEBUG variable to be False by default and can only be changed in the .env file.
- Added the ENVSAMPLE file for contributors which contains default variables or settings to be used in development.
- Added python-decouple in requirements.